### PR TITLE
Correct _PDO_RESPONSE_CODES list

### DIFF
--- a/adafruit_husb238.py
+++ b/adafruit_husb238.py
@@ -143,6 +143,7 @@ class Adafruit_HUSB238:
     _PDO_RESPONSE_CODES = [
         "NO RESPONSE",
         None,  # Success
+        None,  # Reserved
         "INVALID COMMAND OR ARGUMENT",
         "COMMAND NOT SUPPORTED",
         "TRANSACTION FAILED, NO GOOD CRC",


### PR DESCRIPTION
Fixes: #4 

According to the HUSB238 datasheet the value `010` in the `PD_RESPONSE` section of the `PD_STATUS1` register should be reserved.

Updated the `_PDO_RESPONSE_CODES` list to account for this, so that when the list is accessed using the `self.response` value the correct response string is returned.